### PR TITLE
Converted class to swift 4.2

### DIFF
--- a/CenteredCollectionView/Classes/CenteredCollectionViewFlowLayout.swift
+++ b/CenteredCollectionView/Classes/CenteredCollectionViewFlowLayout.swift
@@ -128,11 +128,11 @@ open class CenteredCollectionViewFlowLayout: UICollectionViewFlowLayout {
 		case .horizontal:
 			let pageOffset = CGFloat(index) * pageWidth - collectionView.contentInset.left
 			proposedContentOffset = CGPoint(x: pageOffset, y: collectionView.contentOffset.y)
-			shouldAnimate = fabs(collectionView.contentOffset.x - pageOffset) > 1 ? animated : false
+			shouldAnimate = abs(collectionView.contentOffset.x - pageOffset) > 1 ? animated : false
 		case .vertical:
 			let pageOffset = CGFloat(index) * pageWidth - collectionView.contentInset.top
 			proposedContentOffset = CGPoint(x: collectionView.contentOffset.x, y: pageOffset)
-			shouldAnimate = fabs(collectionView.contentOffset.y - pageOffset) > 1 ? animated : false
+			shouldAnimate = abs(collectionView.contentOffset.y - pageOffset) > 1 ? animated : false
 		}
 		collectionView.setContentOffset(proposedContentOffset, animated: shouldAnimate)
 	}
@@ -176,9 +176,9 @@ private extension CenteredCollectionViewFlowLayout {
 			}
 
 			switch scrollDirection {
-			case .horizontal where fabs(attributes.center.x - proposedCenterOffset) < fabs(candidateAttributes!.center.x - proposedCenterOffset):
+			case .horizontal where abs(attributes.center.x - proposedCenterOffset) < abs(candidateAttributes!.center.x - proposedCenterOffset):
 				candidateAttributes = attributes
-			case .vertical where fabs(attributes.center.y - proposedCenterOffset) < fabs(candidateAttributes!.center.y - proposedCenterOffset):
+			case .vertical where abs(attributes.center.y - proposedCenterOffset) < abs(candidateAttributes!.center.y - proposedCenterOffset):
 				candidateAttributes = attributes
 			default:
 				continue

--- a/CenteredCollectionView/Classes/CenteredCollectionViewFlowLayout.swift
+++ b/CenteredCollectionView/Classes/CenteredCollectionViewFlowLayout.swift
@@ -16,14 +16,14 @@ public extension UICollectionView {
 	///   - centeredCollectionViewFlowLayout: The `CenteredCollectionViewFlowLayout` for the `UICollectionView` to be configured with.
 	public convenience init(frame: CGRect = .zero, centeredCollectionViewFlowLayout: CenteredCollectionViewFlowLayout) {
 		self.init(frame: frame, collectionViewLayout: centeredCollectionViewFlowLayout)
-		decelerationRate = UIScrollViewDecelerationRateFast
+		decelerationRate = UIScrollView.DecelerationRate.fast
 	}
 }
 
 /// A `UICollectionViewFlowLayout` that _pages_ and keeps its cells centered, resulting in the _"carousel effect"_ 🎡
 open class CenteredCollectionViewFlowLayout: UICollectionViewFlowLayout {
 	private var lastCollectionViewSize: CGSize = CGSize.zero
-	private var lastScrollDirection: UICollectionViewScrollDirection!
+	private var lastScrollDirection: UICollectionView.ScrollDirection!
 	private var lastItemSize: CGSize = CGSize.zero
 	var pageWidth: CGFloat {
 		switch scrollDirection {

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -318,7 +318,7 @@
 				LastUpgradeCheck = 0920;
 				TargetAttributes = {
 					7E578E146833132BE80B916DF4390314 = {
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1010;
 					};
 				};
 			};
@@ -494,8 +494,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -527,8 +526,7 @@
 				PRODUCT_NAME = CenteredCollectionView;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
First time committing changes to a cocoapod.
I automatically upgraded to CenteredCollectionViewFlowLayout.swift to swift 4.2 using Xcode, and fixed the warnings Xcode gave.

Resolves: #34 