### PR TITLE
Issue #57 - Support Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let package = Package(
+    name: "CenteredCollectionView",
+    platforms: [
+        .iOS(.v9),
+        .tvOS(.v9)
+    ],
+    products: [
+        .library(name: "CenteredCollectionView", targets: ["CenteredCollectionView"]),
+    ],
+    targets: [
+        .target(name: "CenteredCollectionView", path: "CenteredCollectionView/Classes")
+    ],
+    swiftLanguageVersions: [
+        .v5
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/BenEmdon/CenteredCollectionView.svg?branch=master)](https://travis-ci.org/BenEmdon/CenteredCollectionView)
 [![Version](https://img.shields.io/cocoapods/v/CenteredCollectionView.svg?style=flat)](http://cocoapods.org/pods/CenteredCollectionView)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
-[![SPM compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://swift.org/package-manager/)
+[![SwiftPM compatible](https://img.shields.io/badge/SwiftPM-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
 [![Swift 5.0](https://img.shields.io/badge/Swift-5.0-orange.svg?style=flat)](https://swift.org)
 [![Platform](https://img.shields.io/badge/platforms-iOS%20%7C%20tvOS-orange.svg)](http://cocoapods.org/pods/CenteredCollectionView)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Build Status](https://travis-ci.org/BenEmdon/CenteredCollectionView.svg?branch=master)](https://travis-ci.org/BenEmdon/CenteredCollectionView)
 [![Version](https://img.shields.io/cocoapods/v/CenteredCollectionView.svg?style=flat)](http://cocoapods.org/pods/CenteredCollectionView)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![SPM compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://swift.org/package-manager/)
 [![Swift 5.0](https://img.shields.io/badge/Swift-5.0-orange.svg?style=flat)](https://swift.org)
 [![Platform](https://img.shields.io/badge/platforms-iOS%20%7C%20tvOS-orange.svg)](http://cocoapods.org/pods/CenteredCollectionView)
 
@@ -21,7 +22,14 @@ This pod requires a deployment target of iOS 9.0 or greater
 
 ## Installation
 
-CenteredCollectionView is available through [CocoaPods](http://cocoapods.org) and [Carthage](https://github.com/Carthage/Carthage).
+CenteredCollectionView is available through [Swift Package Manager](https://swift.org/package-manager/), [CocoaPods](http://cocoapods.org) and [Carthage](https://github.com/Carthage/Carthage).
+
+To install it with **Swift Package Manager**, add the URL `https://github.com/BenEmdon/CenteredCollectionView` in Xcode Add Package Dependency assistant ; or add to your own `Package.swift`:
+```swift
+dependencies: [
+  .package(url: "https://github.com/BenEmdon/CenteredCollectionView", from: "2.2.1")
+]
+```
 
 To install it with **Cocoapods**, add the following line to your `Podfile`:
 ```ruby

--- a/USAGE.md
+++ b/USAGE.md
@@ -11,7 +11,14 @@ How to install and use this module.
 
 ## Installation
 
-CenteredCollectionView is available through [CocoaPods](http://cocoapods.org) and [Carthage](https://github.com/Carthage/Carthage).
+CenteredCollectionView is available through [Swift Package Manager](https://swift.org/package-manager/), [CocoaPods](http://cocoapods.org) and [Carthage](https://github.com/Carthage/Carthage).
+
+To install it with **Swift Package Manager**, add the URL `https://github.com/BenEmdon/CenteredCollectionView` in Xcode Add Package Dependency assistant ; or add to your own `Package.swift`:
+```swift
+dependencies: [
+  .package(url: "https://github.com/BenEmdon/CenteredCollectionView", from: "2.2.1")
+]
+```
 
 To install it with **Cocoapods**, add the following line to your `Podfile`:
 ```ruby


### PR DESCRIPTION
Fixes issue #57 - Support Swift Package Manager

- Added Package.swift definition file
- Xcode in SPM mode now complies building for generic tvOS & iOS (open the project folder using Xcode ; no .xcodeproj required)
- Imported the fork using Xcode SPM helper on a personal project. The import worked ; and the class is fully usable.